### PR TITLE
Update null handler to built in laravel instance

### DIFF
--- a/src/Rairlie/LockingSession/Middleware/StartSession.php
+++ b/src/Rairlie/LockingSession/Middleware/StartSession.php
@@ -2,7 +2,8 @@
 namespace Rairlie\LockingSession\Middleware;
 
 use Illuminate\Session\Middleware\StartSession as BaseStartSession;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+use Illuminate\Session\NullSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler as SymfonyNullHandler;
 
 class StartSession extends BaseStartSession
 {
@@ -19,7 +20,7 @@ class StartSession extends BaseStartSession
 
         $handler = $this->manager->driver()->getHandler();
 
-        if ($handler instanceOf NullSessionHandler) {
+        if ($handler instanceOf NullSessionHandler || $handler instanceof  SymfonyNullHandler) {
             return false;
         }
 

--- a/src/Rairlie/LockingSession/SessionManager.php
+++ b/src/Rairlie/LockingSession/SessionManager.php
@@ -2,7 +2,8 @@
 namespace Rairlie\LockingSession;
 
 use Illuminate\Session\SessionManager as BaseSessionManager;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+use Illuminate\Session\NullSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler as SymfonyNullHandler;
 
 class SessionManager extends BaseSessionManager
 {
@@ -12,7 +13,7 @@ class SessionManager extends BaseSessionManager
      */
     protected function buildSession($handler)
     {
-        if ($handler instanceOf NullSessionHandler) {
+        if ($handler instanceOf NullSessionHandler || $handler instanceof SymfonyNullHandler) {
             return parent::buildSession($handler);
         }
 


### PR DESCRIPTION
As of Laravel 5.5 the `NullSessionHandler` instantiated when using an `array` session driver is not the upstream Symfony one but a built in Laravel `NullSessionHandler`

[See: https://github.com/laravel/framework/pull/22314]

Because of this the tests here are always false and thus a locking session handler is created even when it should not be.

This PR just adds the `use` reference to point to the correct Laravel class.

**NOTE** This should also be backwards  compatible since the check looks for instances of either class, although the old Symfony check should be removed once a version of this library is released to support 5.5+